### PR TITLE
Fixing resource default actions.

### DIFF
--- a/resources/default_ruby.rb
+++ b/resources/default_ruby.rb
@@ -23,8 +23,7 @@ actions :create
 
 attribute :ruby_string, :kind_of => String, :name_attribute => true
 
-def initialize(name, run_context=nil)
+def initialize(*args)
   super
   @action = :create
-  @command = name
 end

--- a/resources/environment.rb
+++ b/resources/environment.rb
@@ -23,8 +23,7 @@ actions :create
 
 attribute :ruby_string, :kind_of => String, :name_attribute => true
 
-def initialize(name, run_context=nil)
+def initialize(*args)
   super
   @action = :create
-  @command = name
 end

--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -28,8 +28,7 @@ attribute :source, :kind_of => String
 attribute :options, :kind_of => Hash
 attribute :version, :kind_of => String
 
-def initialize(name, run_context=nil)
+def initialize(*args)
   super
   @action = :install
-  @command = name
 end

--- a/resources/gemset.rb
+++ b/resources/gemset.rb
@@ -24,8 +24,7 @@ actions :create, :delete, :empty, :update
 attribute :gemset,      :kind_of => String, :name_attribute => true
 attribute :ruby_string, :kind_of => String, :regex => /^[^@]+$/
 
-def initialize(name, run_context=nil)
+def initialize(*args)
   super
   @action = :create
-  @command = name
 end

--- a/resources/ruby.rb
+++ b/resources/ruby.rb
@@ -23,8 +23,7 @@ actions :install, :uninstall, :remove
 
 attribute :ruby_string, :kind_of => String, :name_attribute => true
 
-def initialize(name, run_context=nil)
+def initialize(*args)
   super
   @action = :install
-  @command = name
 end

--- a/resources/shell.rb
+++ b/resources/shell.rb
@@ -34,8 +34,7 @@ attribute :timeout,     :kind_of => Integer
 attribute :user,        :kind_of => String
 attribute :umask,       :kind_of => String
 
-def initialize(name, run_context=nil)
+def initialize(*args)
   super
   @action = :run
-  @command = name
 end

--- a/resources/wrapper.rb
+++ b/resources/wrapper.rb
@@ -26,8 +26,7 @@ attribute :ruby_string, :kind_of => String
 attribute :binary,      :kind_of => String
 attribute :binaries,    :kind_of => Array
 
-def initialize(name, run_context=nil)
+def initialize(*args)
   super
   @action = :create
-  @command = name
 end


### PR DESCRIPTION
I'm stuck on chef 0.8.16 for some integration and chef was dying on your resource files.

The documentation (http://wiki.opscode.com/display/chef/Lightweight+Resources+and+Providers+%28LWRP%29#LightweightResourcesandProviders%28LWRP%29-DefaultAction) specifies a different way to define default actions on resources.  I changed your definitions to match and was able to get chef to run.
