### PR TITLE
Fixed bug when no RVM Rubies had yet been installed

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,13 +37,13 @@ end
 include_recipe "rvm::system"
 
 if node['rvm']['install_rubies'] == true || node['rvm']['install_rubies'] == "true"
-  # set a default ruby
-  rvm_default_ruby node['rvm']['default_ruby']
-
   # install additional rubies
   node['rvm']['rubies'].each do |rubie|
     rvm_ruby rubie
   end
+
+  # set a default ruby
+  rvm_default_ruby node['rvm']['default_ruby']
 
   # install global gems
   node['rvm']['global_gems'].each do |gem|


### PR DESCRIPTION
Thanks for the great recipe that solves a lot of the complexities of getting rvm installed system-wide with Chef.  When running this on some brand new systems I ran into an issue where the recipe was assigning a default before any Rubies were installed.  Moving this block of code solves the crash.

Cheers,
Karl
