### PR TITLE
fix providers/ruby.rb bug on ubuntu. Was throwing cannot convert string to array error

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -145,7 +145,7 @@ def install_ruby_dependencies(rubie)
     #include_recipe "java"
     case node['platform']
     when "debian","ubuntu"
-      pkgs += "g++"
+      pkgs += %w{ g++ }
     end
   end
 


### PR DESCRIPTION
fix providers/ruby.rb bug on ubuntu. Was throwing cannot convert string to array error
