### PR TITLE
Fixing NoMethodError when using system wide rvm and the gem_package resource.

### DIFF
--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -125,7 +125,7 @@ class Chef
           ruby_strings.each do |rubie|
             next if rubie == 'system'
             e = rvm_environment rubie do
-              user    new_resource.user if new_resource.respond_to?("user")
+              user    gem_env.user if gem_env.user
               action :nothing
             end
             e.run_action(:create)
@@ -144,13 +144,13 @@ class Chef
             name = @new_resource.source
           end
 
-          cmd = %{rvm #{ruby_strings.join(',')} #{rvm_do(new_resource.user)} #{gem_binary_path}}
+          cmd = %{rvm #{ruby_strings.join(',')} #{rvm_do(gem_env.user)} #{gem_binary_path}}
           cmd << %{ install #{name} -q --no-rdoc --no-ri -v "#{version}"}
           cmd << %{#{src}#{opts}}
 
-          if new_resource.respond_to?("user") && new_resource.user
-            user_dir    = Etc.getpwnam(new_resource.user).dir
-            environment = { 'USER' => new_resource.user, 'HOME' => user_dir }
+          if gem_env.user
+            user_dir    = Etc.getpwnam(gem_env.user).dir
+            environment = { 'USER' => gem_env.user, 'HOME' => user_dir }
           else
             user_dir    = nil
             environment = nil
@@ -164,7 +164,7 @@ class Chef
         end
 
         def uninstall_via_gem_command(name, version)
-          cmd = %{rvm #{ruby_strings.join(',')} #{rvm_do(new_resource.user)} #{gem_binary_path}}
+          cmd = %{rvm #{ruby_strings.join(',')} #{rvm_do(gem_env.user)} #{gem_binary_path}}
           cmd << %{ uninstall #{name} -q -x -I}
           if version
             cmd << %{ -v "#{version}"#{opts}}
@@ -172,9 +172,9 @@ class Chef
             cmd << %{ -a#{opts}}
           end
 
-          if new_resource.respond_to?("user") && new_resource.user
-            user_dir    = Etc.getpwnam(new_resource.user).dir
-            environment = { 'USER' => new_resource.user, 'HOME' => user_dir }
+          if gem_env.user
+            user_dir    = Etc.getpwnam(gem_env.user).dir
+            environment = { 'USER' => gem_env.user, 'HOME' => user_dir }
           else
             user_dir    = nil
             environment = nil


### PR DESCRIPTION
Today I updated the chef-rvm cookbook to head and started getting this error.  It is repeatable for me in vagrant.

Error

``` ruby
NoMethodError: gem_package[god] (god::default line 22) had an error: undefined method `user' for Chef::Resource::GemPackage
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/resource.rb:145:in `method_missing'
/tmp/vagrant-chef-1/chef-solo-1/rvm/libraries/rvm_rubygems_package.rb:147:in `install_via_gem_command'
/tmp/vagrant-chef-1/chef-solo-1/rvm/libraries/rvm_rubygems_package.rb:134:in `install_package'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/provider/package.rb:60:in `action_install'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/resource.rb:417:in `send'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/resource.rb:417:in `run_action'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/runner.rb:45:in `run_action'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/runner.rb:78:in `converge'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/runner.rb:78:in `each'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/runner.rb:78:in `converge'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/resource_collection.rb:94:in `execute_each_resource'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/resource_collection.rb:92:in `execute_each_resource'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/runner.rb:76:in `converge'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/client.rb:312:in `converge'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/client.rb:160:in `run'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/application/solo.rb:192:in `run_application'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/application/solo.rb:183:in `loop'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/application/solo.rb:183:in `run_application'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/../lib/chef/application.rb:66:in `run'
/opt/ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/chef-solo:25
/opt/ruby/bin/chef-solo:19:in `load'
```

Code that causes the error.

``` ruby
gem_package "god" do
  action :install
end
```
