### PR TITLE
Added "-s stable" to the RVM install script.

### DIFF
--- a/libraries/chef_rvm_recipe_helpers.rb
+++ b/libraries/chef_rvm_recipe_helpers.rb
@@ -69,7 +69,7 @@ class Chef
         i = execute exec_name do
           user    opts[:user] || "root"
           command <<-CODE
-            bash -c "bash \
+            bash -c "bash -s stable \
               <( curl -Ls #{opts[:installer_url]} )#{opts[:script_flags]}"
           CODE
           environment(exec_env)


### PR DESCRIPTION
Without this, the installation would exit with code 1, which would cause the recipe to stop, without providing a meaningful error message to ease debugging.
