### PR TITLE
Prevent rvm from reinstalling each chef run

### DIFF
--- a/libraries/chef_rvm_recipe_helpers.rb
+++ b/libraries/chef_rvm_recipe_helpers.rb
@@ -80,7 +80,8 @@ class Chef
           end
 
           not_if  rvm_wrap_cmd(
-            %{type rvm | cat | head -1 | grep -q '^rvm is a function$'}, user_dir)
+            %{type rvm | cat | head -1 | grep -q '^rvm is a function$'}, user_dir),
+            :environment => exec_env
         end
         i.run_action(:run) if install_now
       end


### PR DESCRIPTION
The `not_if` block in the `install_rvm` recipe helper wasn't receiving the correct environment and would always attempt to reinstall rvm.
