### PR TITLE
Fixes NoMethodError Exception: undefined method `patch' for Chef::Resource::RvmGemset

### DIFF
--- a/resources/gemset.rb
+++ b/resources/gemset.rb
@@ -24,7 +24,7 @@ actions :create, :delete, :empty, :update
 attribute :gemset,      :kind_of => String, :name_attribute => true
 attribute :ruby_string, :kind_of => String, :regex => /^[^@]+$/
 attribute :user,        :kind_of => String
-
+attribute :patch,       :kind_of => String
 def initialize(*args)
   super
   @action = :create


### PR DESCRIPTION
The patch attribute is not available in the RvmGemset resource and this results in an error when it is passed to the Chef::RVM::StringHelpers::normalize_ruby_string method as the default value for the patch parameter in that method expects a new_resource.patch. 
