### PR TITLE
Fix for rvm_gem with omnibus, causing issues for gems with native extensions

### DIFF
--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -90,7 +90,9 @@ class Chef
         end
 
         def initialize(new_resource, run_context=nil)
+          original_gem_binary = new_resource.gem_binary
           super
+          new_resource.gem_binary("gem") unless original_gem_binary
           user = new_resource.respond_to?("user") ? new_resource.user : nil
           @gem_env = RVMGemEnvironment.new(gem_binary_path, ruby_strings, user)
         end


### PR DESCRIPTION
The Rubygems provider in current Chef versions, if the resource doesn't declare the gem_binary and the Omnibus package is being used, will set the gem_binary to the first gem binary it can find in the path. If you're using RVM and Omnibus exclusively, then the only gem binary it finds in the PATH is the Omnibus version, so manages to outsmart itself and set the gem_binary to the Omnibus gem binary. So the RVM cookbook then manages to execute something along the lines of `rvm x,y,z do /opt/chef/embedded/bin/gem install …`, using the wrong version of Ruby to install the gem into the right set of Rubygems.

Amazingly, this actually works in many cases. When it doesn't work is if the gem includes native extensions that must be compiled and those extensions care what version of Ruby they're being compiled against. My use case is installing the home_run extension into REE but it was being compiled against the Omnibus 1.9 version of Ruby.

This patch prevents Chef from outsmarting itself by resetting the gem_binary to simply "gem" if the user of the rvm_gem resource didn't explicitly set their own gem_binary.
