### PR TITLE
changing gem install to use chef_gem

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,9 +18,7 @@
 #
 
 # install rvm api gem during chef compile phase
-gem_package 'rvm' do
-  action :nothing
-end.run_action(:install)
+chef_gem 'rvm'
 
 require 'rubygems'
 Gem.clear_paths


### PR DESCRIPTION
I'm working to migrate over to the omnibus installer for chef.  After switching, the rvm::system recipe was failing with the following error:

FATAL: LoadError: no such file to load -- rvm

I'm not exactly sure what is going on, but I think it has something to do with the omnibus rubygems and system rubygems being different.  Switching the gem install to chef_gem fixed the problem for me.  Again, I don't really understand the details of the omnibus packaging yet, so I'm not sure if this change is "safe" or not for people using the recipe under different circumstances.
