### PR TITLE
Make work on centos by installing rvm gem into chef's embedded ruby.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,13 @@ gem_package 'rvm' do
   action :nothing
 end.run_action(:install)
 
+# install rvm gem for embedded chef.   centos 6.2 picks up the embedded
+# ruby instead of system ruby so we need to install the rvm gem there to
+# make this work on centos
+chef_gem 'rvm' do
+  action :nothing
+end.run_action(:install)
+
 require 'rubygems'
 Gem.clear_paths
 require 'rvm'


### PR DESCRIPTION
Confirmed this made Centos 6.2 work and confirmed it doesn't break Ubuntu 11.10

Without this fix you'll see this on Centos 6.2:

[2012-09-20T17:06:23-04:00] INFO: **\* Chef 10.14.2 ***
[2012-09-20T17:06:24-04:00] INFO: Setting the run_list to ["role[jenkins_slave]"] from JSON
[2012-09-20T17:06:24-04:00] INFO: Run List is [role[jenkins_slave]]
[2012-09-20T17:06:24-04:00] INFO: Run List expands to [jenkins_slave]
[2012-09-20T17:06:24-04:00] INFO: Starting Chef Run for ip-10-252-90-98.us-west-2.compute.internal
[2012-09-20T17:06:24-04:00] INFO: Running start handlers
[2012-09-20T17:06:24-04:00] INFO: Start handlers complete.
[2012-09-20T17:06:24-04:00] INFO: Processing gem_package[rvm] action install (rvm::default line 21)
# 
# Recipe Compile Error in /tmp/exec/cookbooks/jenkins_slave/recipes/default.rb
## LoadError

cannot load such file -- rvm
## Cookbook Trace:

  /tmp/exec/cookbooks/rvm/recipes/default.rb:27:in `from_file'
  /tmp/exec/cookbooks/rvm/recipes/system_install.rb:20:in`from_file'
  /tmp/exec/cookbooks/rvm/recipes/system.rb:20:in `from_file'
  /tmp/exec/cookbooks/jenkins_slave/recipes/default.rb:4:in`from_file'
## Relevant File Content:

/tmp/exec/cookbooks/rvm/recipes/default.rb:

  1:  #
  2:  # Cookbook Name:: rvm
  3:  # Recipe:: default
  4:  #
  5:  # Copyright 2010, 2011, Fletcher Nichol
  6:  #
  7:  # Licensed under the Apache License, Version 2.0 (the "License");
  8:  # you may not use this file except in compliance with the License.
  9:  # You may obtain a copy of the License at

[2012-09-20T17:06:25-04:00] ERROR: Running exception handlers
[2012-09-20T17:06:25-04:00] ERROR: Exception handlers complete
[2012-09-20T17:06:25-04:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2012-09-20T17:06:25-04:00] FATAL: LoadError: cannot load such file -- rvm
