### PR TITLE
allows for universal rvmrc settings to be used in the user_install

### DIFF
--- a/recipes/user_install.rb
+++ b/recipes/user_install.rb
@@ -31,7 +31,7 @@ Array(node['rvm']['user_installs']).each do |rvm_user|
   rvm_prefix        = rvm_user['home'] ||
                       "#{node['rvm']['user_home_root']}/#{rvm_user['user']}"
   rvm_gem_options   = rvm_user['rvm_gem_options'] || node['rvm']['rvm_gem_options']
-  rvmrc             = rvm_user['rvmrc'] || Hash.new
+  rvmrc             = rvm_user['rvmrc'] || node['rvm']['rvmrc'] 
 
   rvmrc_template  :rvm_prefix => rvm_prefix,
                   :rvm_gem_options => rvm_gem_options,


### PR DESCRIPTION
If there is no user specific rvmrc hash, attempt to use the global rvmrc hash.
