### PR TITLE
Change Vagrant Recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,8 +20,8 @@
 #
 
 # ruby that will get installed and set to `rvm use default`.
-default['rvm']['default_ruby']      = "ruby-1.9.3-p194"
-default['rvm']['user_default_ruby'] = "ruby-1.9.3-p194"
+default['rvm']['default_ruby']      = "ruby-1.9.3-p286"
+default['rvm']['user_default_ruby'] = "ruby-1.9.3-p286"
 
 # list of additional rubies that will be installed
 default['rvm']['rubies']      = []

--- a/recipes/system.rb
+++ b/recipes/system.rb
@@ -30,8 +30,10 @@ if perform_install_rubies
 end
 
 # add users to rvm group
-group 'rvm' do
-  members node['rvm']['group_users']
-
-  only_if { node['rvm']['group_users'].any? }
+if node['rvm']['group_users'].any? 
+  group 'rvm' do
+    members node['rvm']['group_users']
+    append true
+    # only_if { node['rvm']['group_users'].any? }
+  end
 end

--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -31,12 +31,16 @@ install_pkg_prereqs
 # Build the rvm group ahead of time, if it is set. This allows avoiding
 # collision with later processes which may set a guid explicitly
 if node['rvm']['group_id'] != 'default'
-  g = group 'rvm' do
+  group 'rvm' do
     group_name 'rvm'
     gid        node['rvm']['group_id']
-    action     :nothing
+    action     :create
   end
-  g.run_action(:create)
+else 
+  group 'rvm' do
+    group_name 'rvm'
+    action :create
+  end
 end
 
 rvmrc_template  :rvm_prefix => rvm_prefix,

--- a/recipes/vagrant.rb
+++ b/recipes/vagrant.rb
@@ -21,7 +21,8 @@ rvm_global_gem "chef" do
   action :upgrade
 end
 
-group "rvm" do
-  members ["vagrant"]
+group 'rvm' do
+  members 'vagrant'
   append  true
+  action :modify
 end


### PR DESCRIPTION
Hello,
Instead of trying to link Chef to the version already install, why not installing the Chef gem in the default installation ?
I provide the patch for the vagrant recipe.
Thanks
