### PR TITLE
Fix vagrant_ruby default location

### DIFF
--- a/attributes/vagrant.rb
+++ b/attributes/vagrant.rb
@@ -19,5 +19,5 @@
 # limitations under the License.
 #
 
-default['rvm']['vagrant']['system_chef_client'] = "/opt/ruby/bin/chef-client"
-default['rvm']['vagrant']['system_chef_solo'] = "/opt/ruby/bin/chef-solo"
+default['rvm']['vagrant']['system_chef_client'] = "/opt/vagrant_ruby/bin/chef-client"
+default['rvm']['vagrant']['system_chef_solo'] = "/opt/vagrant_ruby/bin/chef-solo"


### PR DESCRIPTION
Fixes https://github.com/fnichol/chef-rvm/issues/121

Vagrant system ruby is now at /opt/vagrant_ruby/ on their default boxes.
