### PR TITLE
update rvm requirements

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -139,7 +139,8 @@ def install_ruby_dependencies(rubie)
         pkgs += %w{ git subversion autoconf } if rubie =~ /^ruby-head$/
       when "centos","redhat","fedora","scientific","amazon"
         pkgs = %w{ gcc-c++ patch readline readline-devel zlib zlib-devel
-                   libyaml-devel libffi-devel openssl-devel }
+                   libyaml-devel libffi-devel openssl-devel
+                   make bzip2 autoconf automake libtool bison }
         pkgs += %w{ git subversion autoconf } if rubie =~ /^ruby-head$/
     end
   when /^jruby-/


### PR DESCRIPTION
These are also required to build MRI rubies, at least on SL6
