### PR TITLE
Update providers/ruby.rb

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -125,11 +125,10 @@ def install_ruby_dependencies(rubie)
   when /^ruby-/, /^ree-/, /^rbx-/, /^kiji/
     case node['platform']
       when "debian","ubuntu"
-        pkgs  = %w{ build-essential openssl libreadline6 libreadline6-dev
-                    zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-dev
-                    sqlite3 libxml2-dev libxslt-dev autoconf libc6-dev
-                    ncurses-dev automake libtool bison ssl-cert }
-        pkgs += %w{ subversion }  if rubie =~ /^ruby-head$/
+        pkgs = %w{ build-essential openssl libreadline6 libreadline6-dev
+                   zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-dev
+                   sqlite3 libxml2-dev libxslt-dev autoconf libc6-dev
+                   ncurses-dev automake libtool bison ssl-cert subversion pkg-config }
       when "suse"
         pkgs = %w{ gcc-c++ patch zlib zlib-devel libffi-devel
                    sqlite3-devel libxml2-devel libxslt-devel }


### PR DESCRIPTION
Latest RVM has modified platform dependencies, requiring subversion and pkg-config to install MRI correctly.
