### PR TITLE
Explicitly provide action :install in chef_gem call

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@
 
 # install rvm api gem during chef compile phase
 chef_gem 'rvm' do
+  action :install
   version '>= 1.11.3.6'
 end
 require 'rvm'


### PR DESCRIPTION
Fixes: Error executing action `install` on resource 'chef_gem[rvm]'

>  executing action `install` on resource 'chef_gem[rvm]'
> *\* [out :: 10.0.1.2] NoMethodError
> *\* [out :: 10.0.1.2] -------------
> *\* [out :: 10.0.1.2] undefined method `full_name' for nil:NilClass
