### PR TITLE
Added missing dependencies.

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -132,7 +132,7 @@ def install_ruby_dependencies(rubie)
         pkgs  = %w{ build-essential openssl libreadline6 libreadline6-dev
                     zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-dev
                     sqlite3 libxml2-dev libxslt-dev autoconf libc6-dev
-                    ncurses-dev automake libtool bison ssl-cert }
+                    ncurses-dev automake libtool bison ssl-cert pkg-config libgdbm-dev libffi-dev}
         pkgs += %w{ subversion }  if rubie =~ /^ruby-head$/
       when "suse"
         pkgs = %w{ gcc-c++ patch zlib zlib-devel libffi-devel


### PR DESCRIPTION
When using the recipe on a new ubuntu 12.04 machine through vagrant, the recipe didn't installed the rubies and rvm complained about these three missing packages: pkg-config, libgdbm-dev and libffi-dev. 
I've added them and tested it on a new machine.
The change was based on this pull request: https://github.com/fnichol/chef-rvm/pull/153
