### PR TITLE
Fix docs: default ruby is 1.9.3-p327

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ The default Ruby for RVM installed system-wide. If the RVM Ruby is not
 installed, it will be built as a pre-requisite. The value can also contain a
 gemset in the form of `"ruby-1.8.7-p352@awesome"`.
 
-The default is `"ruby-2.0.0-p0"`. To disable a default Ruby from being
+The default is `"ruby-1.9.3-p327"`. To disable a default Ruby from being
 set, use an empty string (`""`) or a value of `"system"`.
 
 ### <a name="attributes-user-default-ruby"></a> user_default_ruby
@@ -262,7 +262,7 @@ The default Ruby for RVMs installed per-user when not explicitly set for that
 user. If the RVM Ruby is not installed, it will be built as a pre-requisite.
 The value can also contain a gemset in the form of `"ruby-1.8.7-p352@awesome"`.
 
-The default is `"ruby-2.0.0-p0"`. To disable a default Ruby from being
+The default is `"ruby-1.9.3-p327"`. To disable a default Ruby from being
 set, use an empty string (`""`) or a value of `"system"`.
 
 ### <a name="attributes-rubies"></a> rubies


### PR DESCRIPTION
The documentation states it was 2.0.0, but that's not right. Related to #150.
