### PR TITLE
V0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Documentation
 
+* Pull request [#284](https://github.com/fnichol/chef-rvm/pull/284): Use full class name for rvm_environment resource usage inside Chef::Provider::Package:RVMRubygems class. ([@nomadium][])
 * Pull request [#246](https://github.com/fnichol/chef-rvm/pull/246): Updated README.md documenting use with librarian-chef ([@ncreuschling][])
 
 ## 0.9.2 (March 31, 2014)
@@ -233,3 +234,4 @@ seen by checking the tagged releases and reading git commit messages.
 [@dosire]: https://github.com/dosire
 [@zsol]: https://github.com/zsol
 [@ncreuschling]: https://github.com/ncreuschling
+[@nomadium]: https://github.com/nomadium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.3 (Unreleased)
+## 0.9.4 (June 3, 2015)
 
 ### Improvements
 

--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -146,7 +146,7 @@ class Chef
           end
 
           cmd = %{rvm #{ruby_strings.join(',')} #{rvm_do(gem_env.user)} #{gem_binary_path}}
-          cmd << %{ install #{name} -q --no-rdoc --no-ri -v "#{version}"}
+          cmd << %{ install #{name} -q --no-document -v "#{version}"}
           cmd << %{#{src}#{opts}}
 
           if gem_env.user

--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -126,10 +126,9 @@ class Chef
           # ensure each ruby is installed and gemset exists
           ruby_strings.each do |rubie|
             next if rubie == 'system'
-            e = rvm_environment rubie do
-              user    gem_env.user if gem_env.user
-              action :nothing
-            end
+            e = ::Chef::Resource::RvmEnvironment.new(rubie, @run_context)
+            e.user(gem_env.user) if gem_env.user
+            e.action(:nothing)
             e.run_action(:create)
           end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name              "rvm"
-maintainer        "Fletcher Nichol"
-maintainer_email  "fnichol@nichol.ca"
+maintainer        "Aaron Kalin"
+maintainer_email  "akalin@martinisoftware.com"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.9.3"
+version           "0.9.4"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."


### PR DESCRIPTION
# Description

Updates `--no-ri --no-rdoc` to `--no-document`

## Issues Resolved

Fixes this issue: https://github.com/sous-chefs/rvm/issues/374

I'm just putting this up here for visibility since there isn't a way to cleanly merge this without a corresponding branch in the main repo. Anyone who needs this can use the `v0.9.5` branch on `reamaze/rvm` temporarily.
