### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,16 +18,16 @@
 - `libraries/` - Library helpers to assist with the cookbook. May contain multiple files depending on complexity of the cookbook.
 - `templates/` - ERB templates that may be used in the cookbook
 - `files/` - files that may be used in the cookbook
-- `metadata.rb`, `Berksfile` - Cookbook metadata and dependencies
+- `metadata.rb`, `Policyfile.rb` - Cookbook metadata and dependencies
 
 ## Build and Test System
 
 ### Environment Setup
-**MANDATORY:** Install Chef Workstation first - provides chef, berks, cookstyle, kitchen tools.
+**MANDATORY:** Install Chef Workstation first - provides chef, cookstyle, kitchen tools.
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb      # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf'
 gem 'chefspec', '>= 9.3.7'
 gem 'cookstyle'
 gem 'fauxhai-chef'

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'rvm'
+
+run_list 'test::default'
+
+cookbook 'rvm', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -89,10 +89,8 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
+# Dependency cache #
+####################
 cookbooks/*
 tmp
 
@@ -104,7 +102,6 @@ Gemfile.lock
 
 # Policyfile #
 ##############
-Policyfile.rb
 Policyfile.lock.json
 
 # Documentation #

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -31,18 +31,21 @@ platforms:
 
 suites:
   - name: default
+    named_run_list: default
     run_list: recipe[test::default]
     verifier:
       inspec_tests:
         - path: test/integration/default
 
   - name: system_install
+    named_run_list: system_install
     run_list: recipe[test::system_install]
     verifier:
       inspec_tests:
         - path: test/integration/default
 
   - name: user_install
+    named_run_list: user_install
     run_list: recipe[test::user_install]
     verifier:
       inspec_tests:


### PR DESCRIPTION
## Summary
- add Policyfile.rb and remove Berksfile
- update Copilot dependency setup to run chef install Policyfile.rb
- remove stale Berkshelf packaging ignores and references

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec
- git diff --check
- kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list